### PR TITLE
Dissoc properties and always write newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## 0.1.1 - 2018-08-16
+
+- Remove `:properties` map from analyzed errors returned by aviso, helps prevent cheshire json conversion errors
+- Put `newline` writing for connection in a `finally` to make sure any errors on a line don't effect the following logging message
+
 ## 0.1.0 - 2018-02-16
 ### Added
 Initial Release

--- a/src/yummly/logentries_timbre_appender.clj
+++ b/src/yummly/logentries_timbre_appender.clj
@@ -38,8 +38,14 @@
   (when e
     (binding [io.aviso.exception/*fonts* nil]
       (let [errors (io.aviso.exception/analyze-exception e {})]
-        (try (mapv #(update % :stack-trace (fn [stack-trace]
-                                             (into [] stack-trace-processor stack-trace)))
+        (try (mapv #(-> %
+                        (update :stack-trace (fn [stack-trace]
+                                               (into [] stack-trace-processor stack-trace)))
+                        ;; :properties can contain values unknown to
+                        ;; cheshire, so just drop it if it exists so
+                        ;; the log message is less likely to fail to
+                        ;; be converted to json
+                        (dissoc :properties))
                    errors)
              (catch Exception e
                (remove :omitted errors)))))))


### PR DESCRIPTION
- Dissoc `:properties` key returned by aviso to prevent unknown data types from causing errors when being converted to json by cheshire
- use `finally` to force writing a new line even if the data conversion fails