### PR TITLE
Show elipses for omitted frames

### DIFF
--- a/src/yummly/logentries_timbre_appender.clj
+++ b/src/yummly/logentries_timbre_appender.clj
@@ -15,12 +15,13 @@
 
 (def iso-format "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
 
-(def stack-trace-processor (comp (remove :omitted)
-                                 (map (fn [stack-frame]
-                                        (format "%s (%s:%s)"
-                                                (:formatted-name stack-frame)
-                                                (:file stack-frame)
-                                                (:line stack-frame))))))
+(def stack-trace-processor (map (fn [stack-frame]
+                                  (if (:omitted stack-frame)
+                                    (:formatted-name stack-frame)
+                                    (format "%s (%s:%s)"
+                                            (:formatted-name stack-frame)
+                                            (:file stack-frame)
+                                            (:line stack-frame))))))
 
 (defn error-to-stacktrace
   "Create a tersely formatted vector of stack traces. This will show up in a


### PR DESCRIPTION
The error process from aviso already removes duplicate omitted frames
and replaces it with a simple "...". Instead of just dropping this
elipses, go ahead and make sure it's shown in the logentries logs so we
know that frames were elided over.