### PR TITLE
Clean json keys to remove illegal characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ pom.xml.asc
 .cpcache
 *~
 /.dir-locals.el
+/.idea/
+/lsp/

--- a/deps.edn
+++ b/deps.edn
@@ -6,20 +6,21 @@
                      "https://github.com/cognitect-labs/test-runner",
                      :sha "76568540e7f40268ad2b646110f237a60295fa3c"}},
    :main-opts      ["-m" "cognitect.test-runner" "-d" "test"]},
-  :test   {:extra-deps  {org.clojure/test.check {:mvn/version "RELEASE"}
-                         org.clojure/clojure    {:mvn/version "1.10.0"}}
+  :test   {:extra-deps  {org.clojure/test.check #:mvn {:version "RELEASE"}
+                         org.clojure/clojure    #:mvn {:version "1.10.0"}}
            :extra-paths ["test"]}
   :dev    {:jvm-opts   ["-Dclojure.spec.compile-asserts=true"
                         "-Dclojure.spec.check-asserts=true"
                         "-DTIMBRE_LEVEL=:warn"]
-           :extra-deps {org.clojure/clojure {:mvn/version "1.10.0"}}}
-  :deploy {:extra-deps {deps-deploy {:mvn/version "RELEASE"}}
+           :extra-deps {org.clojure/clojure #:mvn {:version "1.10.1"}
+												criterium           #:mvn {:version "0.4.5"}}}
+  :deploy {:extra-deps {deps-deploy #:mvn {:version "RELEASE"}}
            :main-opts  ["-m" "deps-deploy.deps-deploy" "deploy"
 		                "logentries-timbre-appender.jar"]}
   :jar    {:extra-deps {pack/pack.alpha         {:git/url "https://github.com/juxt/pack.alpha.git"
                                                  :sha     "8acf80dd4d6e5173585f5c6fec7af28a310f3ed7"}
-                        javax.xml.bind/jaxb-api {:mvn/version "2.2.12"}
-                        org.clojure/clojure     {:mvn/version "1.10.0"}}
+                        javax.xml.bind/jaxb-api #:mvn {:version "2.2.12"}
+                        org.clojure/clojure     #:mvn {version "1.10.0"}}
            :main-opts ["-m" "mach.pack.alpha.skinny" "--no-libs"
                        "--project-path" "logentries-timbre-appender.jar"]}},
  :deps {cheshire                           #:mvn {:version "5.8.0"},
@@ -27,4 +28,4 @@
         io.aviso/pretty                    #:mvn {:version "0.1.33"},
         pool                               #:mvn {:version "0.2.1"}
         com.logentries/logentries-appender #:mvn {:version "1.1.38"}
-        javax.xml.bind/jaxb-api            {:mvn/version "2.2.12"}}}
+        javax.xml.bind/jaxb-api            #:mvn {:version "2.2.12"}}}

--- a/src/yummly/logentries_timbre_appender.clj
+++ b/src/yummly/logentries_timbre_appender.clj
@@ -1,10 +1,10 @@
 (ns yummly.logentries-timbre-appender
   "Appender that sends output to Logentries (https://logentries.com/).
    Requires Cheshire (https://github.com/dakrone/cheshire)."
-  {:author "Ryan Smith (@tanzoniteblack), Mike Sperber (@mikesperber), David Frese (@dfrese)"}
+  {:author "Ryan Smith (@tanzoniteblack), Vadim Geshel (@vgeshel)"}
   (:require [cheshire.core :as cheshire]
             [io.aviso.exception]
-            [clojure.string])
+            [clojure.string :as s])
   (:import [com.logentries.net AsyncLogger]))
 
 (defn ^AsyncLogger make-logger [{:keys [token debug?]}]
@@ -39,25 +39,38 @@
                         ;; be converted to json
                         (dissoc :properties))
                    errors)
-             (catch Exception e
+             (catch Exception _
                (remove :omitted errors)))))))
 
+(def illegal-key-characters #"[^a-zA-Z0-9@\$\._]")
+
+(defn clean-key
+  "InsightOps only supports alphanumeric values along with `@`, `$`, `_`, and `.` in keys. This function
+  replaces all illegal characters in a string/keyword with a `.`. See https://docs.logentries.com/docs/json#section-kvp-parsing-specification for details."
+  [k]
+  (s/replace (name k) illegal-key-characters "."))
+
 (defn data->json-line
+  "Create a JSON string to be sent to logentries, will clean keys of illegal characters by applying `clean-key`.
+
+   N.B. Cheshire only applies `:key-fn` to keywords, not strings. So if a key is explicitly a string, then it will be passed through as is.
+   While we could use clojure.walk to clean up all keys, it's an order of magnitude slower."
   [data user-tags stacktrace-fn]
   ;; Note: this it meant to target the logstash-filter-json; especially "message" and "@timestamp" get a special meaning there.
   (cheshire/generate-string
-   (merge user-tags
-          (:context data)
-          {:level       (:level data)
-           :namespace   (:?ns-str data)
-           :file        (:?file data)
-           :line        (:?line data)
-           :stacktrace  (stacktrace-fn (:?err data))
-           :hostname    (force (:hostname_ data))
-           :message     (force (:msg_ data))
-           "@timestamp" (:instant data)})
-   {:date-format iso-format
-    :pretty      false}))
+    (merge user-tags
+           (:context data)
+           {:level       (:level data)
+            :namespace   (:?ns-str data)
+            :file        (:?file data)
+            :line        (:?line data)
+            :stacktrace  (stacktrace-fn (:?err data))
+            :hostname    (force (:hostname_ data))
+            :message     (force (:msg_ data))
+            "@timestamp" (:instant data)})
+    {:date-format iso-format
+     :pretty      false
+     :key-fn      clean-key}))
 
 (defn logentries-appender
   "Returns a Logentries appender, which will send each event in JSON format to the
@@ -71,11 +84,7 @@
 
   Note that `cheshire.core` is used to serialize log messages to json. If something in your `:user-tags` or `:context` is not readily serializable by `cheshire`, this will cause exceptions and those messages *will not* be logged. See https://github.com/dakrone/cheshire#custom-encoders for how to teach `chechire` to encode your custom data."
   [token & [opts]]
-  (let [conn            (atom nil)
-        flush?          (or (:flush? opts) false)
-        nl              "\n"
-        stacktrace-fn   (:stack-trace-fn opts error-to-stacktrace)
-        ssl?            (:ssl? opts false)
+  (let [stacktrace-fn   (:stack-trace-fn opts error-to-stacktrace)
         debug?          (:debug? opts false)]
     (let [logger                      (make-logger {:token token :debug? debug?})
           last-error-report-timestamp (atom 0)

--- a/src/yummly/logentries_timbre_appender.clj
+++ b/src/yummly/logentries_timbre_appender.clj
@@ -48,7 +48,7 @@
   "InsightOps only supports alphanumeric values along with `@`, `$`, `_`, and `.` in keys. This function
   replaces all illegal characters in a string/keyword with a `.`. See https://docs.logentries.com/docs/json#section-kvp-parsing-specification for details."
   [k]
-  (s/replace (name k) illegal-key-characters "."))
+  (s/replace (name k) illegal-key-characters "_"))
 
 (defn data->json-line
   "Create a JSON string to be sent to logentries, will clean keys of illegal characters by applying `clean-key`.

--- a/test/yummly/logentries_timbre_appender_test.clj
+++ b/test/yummly/logentries_timbre_appender_test.clj
@@ -12,3 +12,14 @@
     (is (pos? (count (:stack-trace parsed-error)))
         "At the very least, we should have a stack trace from the nested function call")
     (is (every? string? (:stack-trace parsed-error)))))
+
+(deftest update-illegal-characters
+  (let [test-line (cheshire/parse-string (sut/data->json-line {:msg_ {:test-data {:test-data             5
+                                                                                  (keyword "casdf asdf") "dog"}}}
+                                                              {:user-data :dog} identity))]
+    (is (= (get test-line "message")
+           {"test.data" {"test.data"  5
+                         "casdf.asdf" "dog"}}))
+    (is (= (get test-line "user.data")
+           "dog"))))
+

--- a/test/yummly/logentries_timbre_appender_test.clj
+++ b/test/yummly/logentries_timbre_appender_test.clj
@@ -18,8 +18,7 @@
                                                                                   (keyword "casdf asdf") "dog"}}}
                                                               {:user-data :dog} identity))]
     (is (= (get test-line "message")
-           {"test.data" {"test.data"  5
-                         "casdf.asdf" "dog"}}))
-    (is (= (get test-line "user.data")
+           {"test_data" {"test_data"  5
+                         "casdf_asdf" "dog"}}))
+    (is (= (get test-line "user_data")
            "dog"))))
-


### PR DESCRIPTION
InsightOps (formerly logentries), only supports a certain set of characters in keys (see https://docs.logentries.com/docs/json#section-kvp-parsing-specification).
This updates the code to replace all illegal characters with `.`.